### PR TITLE
Add bot resources and state

### DIFF
--- a/src/main/java/game/model/Bot.java
+++ b/src/main/java/game/model/Bot.java
@@ -1,12 +1,25 @@
 package game.model;
 
 import game.model.tile.Tile;
+import game.model.ResourceType;
 import game.strategies.BotStrategy;
+import java.util.EnumMap;
+import java.util.Map;
+
+/** Bot that moves around the map and stores resources and state. */
 
 public class Bot {
   public BotStrategy strategy;
   public Tile currentTile;
   public Integer maximumActions;
+  // map of resources currently held by the bot
+  public Map<ResourceType, Integer> resources = new EnumMap<>(ResourceType.class);
+
+  // health and psychological state
+  public Integer healthCap;
+  public Integer health;
+  public Integer psycheCap;
+  public Integer psyche;
 
   public Bot(BotStrategy botStrategy, Tile startTile, Integer maximumActions) {
     this.strategy = botStrategy;
@@ -15,6 +28,17 @@ public class Bot {
 
     actionsRemaining = maximumActions;
     isDone = false;
+
+    // initialize resources to zero
+    for (ResourceType type : ResourceType.values()) {
+      resources.put(type, 0);
+    }
+
+    // default state capacities
+    healthCap = 100;
+    health = healthCap;
+    psycheCap = 100;
+    psyche = psycheCap;
   }
 
   public Integer actionsRemaining;

--- a/src/main/java/game/model/ResourceType.java
+++ b/src/main/java/game/model/ResourceType.java
@@ -1,0 +1,19 @@
+package game.model;
+
+/** Different resources that a bot can store. */
+public enum ResourceType {
+  FOOD(50),
+  BUILDING_MATERIAL(50),
+  MEDICINE(30),
+  SPECIAL(10);
+
+  private final int cap;
+
+  ResourceType(int cap) {
+    this.cap = cap;
+  }
+
+  public int cap() {
+    return cap;
+  }
+}


### PR DESCRIPTION
## Summary
- add `ResourceType` enum with capacities
- extend `Bot` with resource map and health/psyche state fields
- initialize resources and state in bot constructor

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5f093988322b4e36236cf243d0a